### PR TITLE
[STEP-7] 콘서트 예약 서비스 - 대용량 트래픽&데이터 처리 ③

### DIFF
--- a/src/main/java/kr/hhplus/be/server/reservation/application/event/PaymentEventListener.java
+++ b/src/main/java/kr/hhplus/be/server/reservation/application/event/PaymentEventListener.java
@@ -1,0 +1,53 @@
+package kr.hhplus.be.server.reservation.application.event;
+
+import kr.hhplus.be.server.reservation.application.port.in.PayHistoryUseCase;
+import kr.hhplus.be.server.reservation.application.port.out.ReservationTokenRepository;
+import kr.hhplus.be.server.reservation.domain.PaymentStatus;
+import kr.hhplus.be.server.reservation.domain.PaymentSuccessEvent;
+import kr.hhplus.be.server.reservation.domain.ReservationTokenStatus;
+import kr.hhplus.be.server.reservation.infrastructure.external.RedisReservationRankingManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentEventListener {
+    private final RedisReservationRankingManager redisReservationRankingManager;
+    private final ReservationTokenRepository reservationTokenRepository;
+    private final PayHistoryUseCase payHistoryUseCase;
+
+    // 비동기로 이벤트 발행주체의 트랜잭션이 커밋된 후에 수행한다.
+    // 1) 예매율 랭킹 Redis 갱신 (일간, 주간, 월간)
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleReservationRanking(PaymentSuccessEvent event) {
+        int scheduleId = event.getConcertScheduleId();
+        redisReservationRankingManager.updateDailyReservationRate(scheduleId);
+        redisReservationRankingManager.updateWeeklyReservationRate(scheduleId);
+        redisReservationRankingManager.updateMonthlyReservationRate(scheduleId);
+    }
+
+    // 2) 대기열토큰 결제완료 처리
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleReservationToken(PaymentSuccessEvent event) {
+        reservationTokenRepository.findByIdAndStatus(event.getTokenId(), ReservationTokenStatus.ALLOWED)
+                .ifPresent(token -> {
+                    token.complete();
+                    reservationTokenRepository.save(token);
+                });
+    }
+
+    // 3) 결제 성공 내역 저장
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handlePayHistory(PaymentSuccessEvent event) {
+        payHistoryUseCase.saveSuccessHistory(event.getSeat(), event.getUserId(), PaymentStatus.SUCCESS, null);
+    }
+
+}

--- a/src/main/java/kr/hhplus/be/server/reservation/application/event/PaymentEventPublisher.java
+++ b/src/main/java/kr/hhplus/be/server/reservation/application/event/PaymentEventPublisher.java
@@ -1,0 +1,16 @@
+package kr.hhplus.be.server.reservation.application.event;
+
+import kr.hhplus.be.server.reservation.domain.PaymentSuccessEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentEventPublisher {
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public void success(PaymentSuccessEvent event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/reservation/application/service/ReservationService.java
+++ b/src/main/java/kr/hhplus/be/server/reservation/application/service/ReservationService.java
@@ -4,6 +4,7 @@ import kr.hhplus.be.server.common.exception.DataNotFoundException;
 import kr.hhplus.be.server.concert.domain.Seat;
 import kr.hhplus.be.server.concert.repository.SeatRepository;
 import kr.hhplus.be.server.point.PointService;
+import kr.hhplus.be.server.reservation.application.event.PaymentEventPublisher;
 import kr.hhplus.be.server.reservation.application.port.in.PayHistoryUseCase;
 import kr.hhplus.be.server.reservation.application.port.in.ReservationUseCase;
 import kr.hhplus.be.server.reservation.application.port.out.ReservationTokenRepository;
@@ -15,7 +16,6 @@ import kr.hhplus.be.server.reservation.exception.InvalidSeatStatusException;
 import kr.hhplus.be.server.reservation.exception.InvalidSeatUserStatusException;
 import kr.hhplus.be.server.reservation.exception.RedisDistributedLockException;
 import kr.hhplus.be.server.reservation.infrastructure.external.RedisDistributedLockManager;
-import kr.hhplus.be.server.reservation.infrastructure.external.RedisReservationRankingManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,7 +36,8 @@ public class ReservationService implements ReservationUseCase {
     private final ReservationTokenValidator reservationTokenValidator;
     private final SeatStatusProperties seatStatusProperties;
     private final RedisDistributedLockManager redisDistributedLockManager;
-    private final RedisReservationRankingManager redisReservationRankingManager;
+
+    private final PaymentEventPublisher paymentEventPublisher;
 
     /**
      * 새로고침했을 경우, 대기순번 새로 부여
@@ -131,6 +132,7 @@ public class ReservationService implements ReservationUseCase {
                     // 대기열토큰 검증
                     reservationTokenValidator.validateToken(tokenId);
 
+                    // 좌석 결제 가능 여부 검증
                     // 예외 상황에서도 결제 실패 이력을 반드시 남기기 위한 REQUIRES_NEW 트랜잭션 분리 [payHistoryUseCase.savePayHistory()]
                     try {
                         seat.validatePayable(userId);
@@ -149,18 +151,8 @@ public class ReservationService implements ReservationUseCase {
                     // 좌석 상태 변경
                     seat.pay();     // Dirty Checking OK
 
-                    // 결제완료 후, 에매율 랭킹 Redis 갱신 (일간, 주간, 월간)
-                    int scheduleId = seat.getConcertSchedule().getId();
-                    redisReservationRankingManager.updateDailyReservationRate(scheduleId);
-                    redisReservationRankingManager.updateWeeklyReservationRate(scheduleId);
-                    redisReservationRankingManager.updateMonthlyReservationRate(scheduleId);
-
-                    // 대기열토큰 만료 처리 (JPA dirty checking)
-                    reservationTokenRepository.findByIdAndStatus(tokenId, ReservationTokenStatus.ALLOWED)
-                            .ifPresent(ReservationToken::complete);
-
-                    // 결제내역 저장 [여기는 예외 생기면 롤백되어야 함 => REQUIRED]
-                    payHistoryUseCase.saveSuccessHistory(seat, userId, PaymentStatus.SUCCESS, null);
+                    // 결제 성공 이벤트 발행
+                    paymentEventPublisher.success(new PaymentSuccessEvent(seat.getConcertSchedule().getId(), userId, tokenId, seat));
 
                     return PaymentRespDto.builder()
                             .userId(userId)

--- a/src/main/java/kr/hhplus/be/server/reservation/domain/PaymentSuccessEvent.java
+++ b/src/main/java/kr/hhplus/be/server/reservation/domain/PaymentSuccessEvent.java
@@ -1,0 +1,16 @@
+package kr.hhplus.be.server.reservation.domain;
+
+import kr.hhplus.be.server.concert.domain.Seat;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class PaymentSuccessEvent {
+    private final int concertScheduleId;
+    private final UUID userId;
+    private final UUID tokenId;
+    private final Seat seat;
+}


### PR DESCRIPTION
# [STEP-7] 콘서트 예약 서비스 - 대용량 트래픽&데이터 처리 ③

## Definition of Done (DoD)
- [x] Application Event: 이벤트를 활용하여 트랜잭션과 관심사를 분리하기
- [ ] feedback수정
- [ ] 캐시: 캐시 적용 구간 점검 및 전략 선정, 적용하고 보고서 작성
- [ ] Asynchronous Design: 대기열 기능에 대해 Redis 기반의 설계를 진행


## PR 설명
- 6ed6915
   - 결제 성공 후처리 로직 이벤트 기반으로 분리 (@TransactionalEventListener 적용)


## 리뷰 포인트
**질문) 이벤트 기반 분리 진행한 부분에 대해,,**
현재 ReservationService.pay() 결제 메서드에서의 핵심로직과 부가로직을 아래와 같이 나눠봤습니다.
- 핵심 로직
  - 대기열 토큰 검증
  - 포인트 사용
  - 좌석 상태 변경
- 부가 로직
  -  예매율 랭킹 갱신
  -  대기열 토큰 만료 처리
  -  결제 이력 저장

현재 부가 로직을 @TransactionalEventListener(AFTER_COMMIT) 기반 이벤트로 분리하여 처리하도록 구현했습니다.
(결제이력은 성공이력만 event로 뺐음)

**1) 해당 이벤트를 잘 구현했는지 피드백 받고 싶습니다.**

**2) 결제 이력 저장을 이벤트로 빼낼 때, 조금 헷갈리는?..어떻게 해야할 지 고민인 부분이 있습니다.**
현재 PayHistoryService에서는  
- 성공이력은 핵심로직 트랜잭션 롤백 시, 함께 롤백되어야하므로 @Transactional(REQUIRED)
- 실패이력은 핵심로직 트랜잭션 롤백되어도 실행되어야하므로 @Transactional(REQUIRES_NEW)로 트랜잭션 분리 해놓은 상태입니다.

성공 이력은 어차피 AFTER_COMMIT에서 동작하므로, 이벤트로 분리해도 문제가 없다고 생각하는데,,
실패 이력 부분을 어떻게 해야할지..고민이 됩니다. 현재는 실패부분은 이벤트로 분리하지 않고, ReservationService.pay() 내부에서 try~catch 로 처리하는 부분을 그대로 놔둔상태입니다.
```java
// 기존 ReservationService.pay() 에서 수행되던 결제실패내역 저장 로직
// 예외 상황에서도 결제 실패 이력을 반드시 남기기 위한 REQUIRES_NEW 트랜잭션 분리 [payHistoryUseCase.savePayHistory()]
try {
	seat.validatePayable(userId);
} catch (InvalidSeatStatusException e) {
	payHistoryUseCase.saveFailedHistory(seat, userId, PaymentStatus.FAILED, PaymentReason.INVALID_SEAT_STATUS);
	throw e;
} catch (InvalidSeatUserStatusException e) {
	payHistoryUseCase.saveFailedHistory(seat, userId, PaymentStatus.FAILED, PaymentReason.INVALID_USER);
	throw e;
}
```

지금처럼 핵심로직 쪽 pay메서드의 try-catch 내부에 실패이력 저장 로직을 그대로 두는 것이 나을까요?
아니면 예외발생시 PaymentFailedEvent 같은 걸 발행해서 
@TransactionalEventListener(phase = AFTER_ROLLBACK) 또는
@Transactional(REQUIRES_NEW) 방식으로 이벤트 리스너에서 처리하는 게 좋을까요..?
이벤트 발행하는 로직의 일관성,통일성을 생각하면 분리해서해야하나 생각도 들고,,,
멘토님의 경우라면 어떤식으로 처리하실 지 궁금합니다 ㅎㅎ!!