### PR TITLE
#8_대용량 트래픽&데이터 처리 ④

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,9 @@ dependencies {
 	// Redis
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
+	// Kafka
+	implementation ("org.springframework.kafka:spring-kafka")
+
 	// lombok
 	compileOnly("org.projectlombok:lombok")
 	annotationProcessor("org.projectlombok:lombok")

--- a/docker-compose.kafka.yml
+++ b/docker-compose.kafka.yml
@@ -1,0 +1,69 @@
+version: '3.8'
+
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.6.0
+    hostname: zookeeper
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  broker1:
+    image: confluentinc/cp-kafka:7.6.0
+    hostname: broker1
+    container_name: broker1
+    ports:
+      - "9092:9092"
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker1:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_LOG_RETENTION_MS: 604800000
+      KAFKA_LOG_RETENTION_BYTES: 1073741824
+
+  broker2:
+    image: confluentinc/cp-kafka:7.6.0
+    hostname: broker2
+    container_name: broker2
+    ports:
+      - "9093:9093"
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 2
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker2:29093,PLAINTEXT_HOST://localhost:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_LOG_RETENTION_MS: 604800000
+      KAFKA_LOG_RETENTION_BYTES: 1073741824
+
+  broker3:
+    image: confluentinc/cp-kafka:7.6.0
+    hostname: broker3
+    container_name: broker3
+    ports:
+      - "9094:9094"
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 3
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker3:29094,PLAINTEXT_HOST://localhost:9094
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_LOG_RETENTION_MS: 604800000
+      KAFKA_LOG_RETENTION_BYTES: 1073741824

--- a/src/main/java/kr/hhplus/be/server/reservation/application/service/ReservationService.java
+++ b/src/main/java/kr/hhplus/be/server/reservation/application/service/ReservationService.java
@@ -4,7 +4,6 @@ import kr.hhplus.be.server.common.exception.DataNotFoundException;
 import kr.hhplus.be.server.concert.domain.Seat;
 import kr.hhplus.be.server.concert.repository.SeatRepository;
 import kr.hhplus.be.server.point.PointService;
-import kr.hhplus.be.server.reservation.application.event.PaymentEventPublisher;
 import kr.hhplus.be.server.reservation.application.port.in.PayHistoryUseCase;
 import kr.hhplus.be.server.reservation.application.port.in.ReservationUseCase;
 import kr.hhplus.be.server.reservation.application.port.out.ReservationTokenRepository;

--- a/src/main/java/kr/hhplus/be/server/reservation/dto/kafka/PaymentSuccessMessage.java
+++ b/src/main/java/kr/hhplus/be/server/reservation/dto/kafka/PaymentSuccessMessage.java
@@ -3,7 +3,6 @@ package kr.hhplus.be.server.reservation.dto.kafka;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.util.UUID;
 

--- a/src/main/java/kr/hhplus/be/server/reservation/dto/kafka/PaymentSuccessMessage.java
+++ b/src/main/java/kr/hhplus/be/server/reservation/dto/kafka/PaymentSuccessMessage.java
@@ -1,0 +1,18 @@
+package kr.hhplus.be.server.reservation.dto.kafka;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentSuccessMessage {
+    private int concertScheduleId;
+    private UUID userId;
+    private UUID tokenId;
+    private int seatId;
+}

--- a/src/main/java/kr/hhplus/be/server/reservation/infrastructure/kafka/PaymentSuccessKafkaConsumer.java
+++ b/src/main/java/kr/hhplus/be/server/reservation/infrastructure/kafka/PaymentSuccessKafkaConsumer.java
@@ -1,0 +1,53 @@
+package kr.hhplus.be.server.reservation.infrastructure.kafka;
+
+import kr.hhplus.be.server.common.exception.DataNotFoundException;
+import kr.hhplus.be.server.concert.domain.Seat;
+import kr.hhplus.be.server.concert.repository.SeatRepository;
+import kr.hhplus.be.server.reservation.application.port.in.PayHistoryUseCase;
+import kr.hhplus.be.server.reservation.application.port.out.ReservationTokenRepository;
+import kr.hhplus.be.server.reservation.domain.PaymentStatus;
+import kr.hhplus.be.server.reservation.domain.ReservationTokenStatus;
+import kr.hhplus.be.server.reservation.dto.kafka.PaymentSuccessMessage;
+import kr.hhplus.be.server.reservation.infrastructure.external.RedisReservationRankingManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentSuccessKafkaConsumer {
+    private final RedisReservationRankingManager redisReservationRankingManager;
+    private final ReservationTokenRepository reservationTokenRepository;
+    private final SeatRepository seatRepository;
+    private final PayHistoryUseCase payHistoryUseCase;
+
+    @Transactional
+    @KafkaListener(topics = "payment_success", groupId = "pay-consumer-group")
+    public void consume(PaymentSuccessMessage message) {
+
+        log.info("1) 랭킹 start");
+        // 1) 예매율 랭킹 Redis 갱신 (일간, 주간, 월간)
+        int scheduleId = message.getConcertScheduleId();
+        redisReservationRankingManager.updateDailyReservationRate(scheduleId);
+        redisReservationRankingManager.updateWeeklyReservationRate(scheduleId);
+        redisReservationRankingManager.updateMonthlyReservationRate(scheduleId);
+
+        log.info("2) 토큰 결제완료 처리");
+        // 2) 대기열토큰 결제완료 처리
+        reservationTokenRepository.findByIdAndStatus(message.getTokenId(), ReservationTokenStatus.ALLOWED)
+                .ifPresent(token -> {
+                    token.complete();
+                    reservationTokenRepository.save(token);
+                });
+
+        log.info("3) 결제 성공내역 저장");
+        // 3) 결제 성공 내역 저장
+        Seat seat = seatRepository.findById(message.getSeatId())
+                .orElseThrow(() -> new DataNotFoundException("좌석이 존재하지 않습니다: seatId = " + message.getSeatId()));
+
+        payHistoryUseCase.saveSuccessHistory(seat, message.getUserId(), PaymentStatus.SUCCESS, null);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/reservation/infrastructure/kafka/PaymentSuccessKafkaConsumer.java
+++ b/src/main/java/kr/hhplus/be/server/reservation/infrastructure/kafka/PaymentSuccessKafkaConsumer.java
@@ -28,14 +28,12 @@ public class PaymentSuccessKafkaConsumer {
     @KafkaListener(topics = "payment_success", groupId = "pay-consumer-group")
     public void consume(PaymentSuccessMessage message) {
 
-        log.info("1) 랭킹 start");
         // 1) 예매율 랭킹 Redis 갱신 (일간, 주간, 월간)
         int scheduleId = message.getConcertScheduleId();
         redisReservationRankingManager.updateDailyReservationRate(scheduleId);
         redisReservationRankingManager.updateWeeklyReservationRate(scheduleId);
         redisReservationRankingManager.updateMonthlyReservationRate(scheduleId);
 
-        log.info("2) 토큰 결제완료 처리");
         // 2) 대기열토큰 결제완료 처리
         reservationTokenRepository.findByIdAndStatus(message.getTokenId(), ReservationTokenStatus.ALLOWED)
                 .ifPresent(token -> {
@@ -43,7 +41,6 @@ public class PaymentSuccessKafkaConsumer {
                     reservationTokenRepository.save(token);
                 });
 
-        log.info("3) 결제 성공내역 저장");
         // 3) 결제 성공 내역 저장
         Seat seat = seatRepository.findById(message.getSeatId())
                 .orElseThrow(() -> new DataNotFoundException("좌석이 존재하지 않습니다: seatId = " + message.getSeatId()));

--- a/src/main/java/kr/hhplus/be/server/reservation/infrastructure/kafka/PaymentSuccessKafkaProducer.java
+++ b/src/main/java/kr/hhplus/be/server/reservation/infrastructure/kafka/PaymentSuccessKafkaProducer.java
@@ -1,0 +1,18 @@
+package kr.hhplus.be.server.reservation.infrastructure.kafka;
+
+import kr.hhplus.be.server.reservation.dto.kafka.PaymentSuccessMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentSuccessKafkaProducer {
+    private final KafkaTemplate<String, PaymentSuccessMessage> kafkaTemplate;
+
+    private static final String TOPIC = "payment_success";
+
+    public void publish(PaymentSuccessMessage message) {
+        kafkaTemplate.send(TOPIC, message);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,6 +36,8 @@ spring:
     redis:
       host: localhost
       port: 6379
+  kafka:
+    bootstrap-servers: localhost:9092
 
 server:
   port: 8082

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,13 +31,21 @@ spring:
     password: application
   sql:
     init:
-      mode: never
+      mode: always
   data:
     redis:
       host: localhost
       port: 6379
   kafka:
     bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    consumer:
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: kr.hhplus.be.server.reservation.dto.kafka
 
 server:
   port: 8082


### PR DESCRIPTION
# [STEP-8] 콘서트 예약 서비스 - 대용량 트래픽&데이터 처리 ④

## Definition of Done (DoD)
- [ ] feedback수정
- [x] 기존에 구현했던 이벤트를 통한 데이터 플랫폼으로의 정보 전달 과정을 Kafka를 통하여 전달하도록 수정

## PR 설명
- a3c085a
   - docker-compose.kafka.yml 파일 활용하여 카프카 클러스트 로컬에서 실행 

- 17b8673
   - 결제 성공 후처리 로직 이벤트 기반으로 분리했던거 Kafka 메시지 발행방식으로 변경

## 리뷰 포인트
안녕하세요~ 이번주 조금 바빠서 급하게 진행했습니다....🫠🫠🫠

- 기존 결제 성공 시 ApplicationEventPublisher로 도메인 이벤트를 발행하던 방식에서, Kafka 메시지 발행 방식으로 변경했습니다.
해당 부분에 대해 피드백 받고 싶습니다~